### PR TITLE
token generation improved

### DIFF
--- a/api/services/emails.service.js
+++ b/api/services/emails.service.js
@@ -54,7 +54,7 @@ module.exports = {
 			rest: "GET /confirm/:token",
 			async handler(ctx){ 
 
-				const token = await Token.findById({ _id: ctx.params.token });
+				const token = await Token.findOne({ token: ctx.params.token });
 
 				if(token) {
 					

--- a/api/services/users.service.js
+++ b/api/services/users.service.js
@@ -83,12 +83,15 @@ module.exports = {
 				/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 				* Generación de token para enviar confirmación al mail del nuevo usuario *
 				* * * * * * * * * * * * *  * * * * * * * * * * * * * * * * * * * * * * * */
-				const token = await Token.create({ _userId: created._id, token: bcrypt.hashSync(created.username, 10) });
+				const rdm = () => ( Math.random().toString(36).substr(2) );
+				const tokenGen = () => ( rdm() + rdm() + rdm() );
+
+				const token = await Token.create({ _userId: created._id, token: tokenGen() });
 
 				/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 				* Llamado al servicio de emails para hacer verificación de la cuenta *
 				* * * * * * * * * * * * *  * * * * * * * * * * * * * * * * * * * * * */
-				await ctx.call('emails.send_email', { email: created.email, token: token._id });
+				await ctx.call('emails.send_email', { email: created.email, token: token.token });
 
 				return created;
 			},


### PR DESCRIPTION
Se cambió la manera de generar el token, ahora solo caracteres alfanuméricos para que la ruta del correo de verificación de clientes funcione correctamente.